### PR TITLE
feat: Remove CPU column from the output table

### DIFF
--- a/proxmox-ram-monitor.sh
+++ b/proxmox-ram-monitor.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Proxmox RAM Usage Monitor v3.4
-# This script provides a summary of RAM and CPU usage for the host, LXC containers, and QEMU/KVM virtual machines.
+# This script provides a summary of RAM usage for the host, LXC containers, and QEMU/KVM virtual machines.
 # It displays a high-level composite bar and a detailed table for all running machines.
 
 # --- Configuration ---
@@ -43,10 +43,6 @@ TOTAL_GUEST_MB=0
 
 # Collect LXC Data
 for lxc_id in $(pct list | awk 'NR>1 && $2=="running" {print $1}'); do
-    # Get CPU from the more reliable 'pct status' command
-    status_output=$(pct status "$lxc_id")
-    lxc_data["$lxc_id", "cpu"]=$(echo "$status_output" | awk '/^cpu:/{printf "%.2f", $2}')
-
     CGROUP_V2_PATH="/sys/fs/cgroup/lxc/${lxc_id}/memory.current"
     CGROUP_V1_PATH="/sys/fs/cgroup/memory/lxc/${lxc_id}/memory.usage_in_bytes"
     
@@ -64,9 +60,6 @@ done
 
 # Collect VM Data
 for vm_id in $(qm list | awk 'NR>1 && $3=="running" {print $1}'); do
-    status_output=$(qm status "$vm_id" 2>/dev/null)
-    vm_data["$vm_id", "cpu"]=$(echo "$status_output" | awk '/^cpu:/{printf "%.2f", $2}')
-
     VM_PID_FILE="/var/run/qemu-server/${vm_id}.pid"
     if [ -f "$VM_PID_FILE" ]; then
         VM_PID=$(cat "$VM_PID_FILE")
@@ -104,15 +97,15 @@ printf "${COLOR_RESET}] ${HOST_TOTAL_USED_PERCENT}%% Used\n"
 printf " ${COLOR_HOST} \033[0m Host   ${COLOR_VM} \033[0m VM     ${COLOR_LXC} \033[0m LXC    ${COLOR_BAR_EMPTY} \033[0m Free\n\n"
 
 # --- 2. Detailed Usage Table ---
-printf "${COLOR_TABLE_HEADER}%-6s %-5s %-20s %-8s %-12s %-12s %s${COLOR_RESET}\n" "TYPE" "ID" "NAME" "CPU %" "RAM USED" "RAM MAX" "TOP PROCESS"
+printf "${COLOR_TABLE_HEADER}%-6s %-5s %-20s %-12s %-12s %s${COLOR_RESET}\n" "TYPE" "ID" "NAME" "RAM USED" "RAM MAX" "TOP PROCESS"
 
 # Host Info
 HOST_TOP_PROC=$(ps aux --sort=-%mem | awk 'NR==2{split($11,a,"/"); printf "%.1f%% %s", $4, a[length(a)]}')
-printf "%-6s %-5s %-20s %-8s %-12s %-12s %s\n" \
-    "Host" "---" "Proxmox VE" "---" "${HOST_ONLY_MB} MB" "${TOTAL_RAM_MB} MB" "${HOST_TOP_PROC}"
+printf "%-6s %-5s %-20s %-12s %-12s %s\n" \
+    "Host" "---" "Proxmox VE" "${HOST_ONLY_MB} MB" "${TOTAL_RAM_MB} MB" "${HOST_TOP_PROC}"
 if [ "$ZFS_CACHE_MB" -gt 0 ]; then
-    printf "%-6s %-5s %-20s %-8s %-12s %-12s %s\n" \
-        "" "" "  |-> ZFS Cache" "---" "${ZFS_CACHE_MB} MB" "---" ""
+    printf "%-6s %-5s %-20s %-12s %-12s %s\n" \
+        "" "" "  |-> ZFS Cache" "${ZFS_CACHE_MB} MB" "---" ""
 fi
 
 # LXC Containers
@@ -120,11 +113,10 @@ for lxc_id in $(for key in "${!lxc_data[@]}"; do echo "$key"; done | cut -d, -f1
     LXC_NAME=$(pct config "$lxc_id" | awk '/^hostname:/{print $2}')
     LXC_USED_MB=${lxc_data[$lxc_id, "ram_used"]}
     LXC_MAX_MB=$(pct config "$lxc_id" | awk '/^memory:/{print $2}')
-    LXC_CPU=${lxc_data[$lxc_id, "cpu"]}
     LXC_TOP_PROC=$(pct exec "$lxc_id" -- ps aux --sort=-%mem | awk 'NR==2{split($11,a,"/"); printf "%.1f%% %s", $4, a[length(a)]}' || echo "N/A")
     
-    printf "%-6s %-5s %-20s %-8s %-12s %-12s %s\n" \
-        "LXC" "$lxc_id" "$LXC_NAME" "$LXC_CPU" "${LXC_USED_MB} MB" "${LXC_MAX_MB:-No limit} MB" "$LXC_TOP_PROC"
+    printf "%-6s %-5s %-20s %-12s %-12s %s\n" \
+        "LXC" "$lxc_id" "$LXC_NAME" "${LXC_USED_MB} MB" "${LXC_MAX_MB:-No limit} MB" "$LXC_TOP_PROC"
 done
 
 # QEMU VMs
@@ -132,12 +124,11 @@ for vm_id in $(for key in "${!vm_data[@]}"; do echo "$key"; done | cut -d, -f1 |
     VM_NAME=$(qm config "$vm_id" | awk '/^name:/{print $2}')
     VM_USED_MB=${vm_data[$vm_id, "ram_used"]}
     VM_MAX_MB=$(qm config "$vm_id" | awk '/^memory:/{print $2; exit}')
-    VM_CPU=${vm_data[$vm_id, "cpu"]}
     # FIX: Wrap the command for 'exec' in 'sh -c' to handle arguments correctly.
     VM_TOP_PROC=$(timeout 2 qm agent "$vm_id" exec -- sh -c 'ps aux --sort=-%mem' 2>/dev/null | awk 'NR==2{split($11,a,"/"); printf "%.1f%% %s", $4, a[length(a)]}' || echo "Agent N/A")
     
-    printf "%-6s %-5s %-20s %-8s %-12s %-12s %s\n" \
-        "VM" "$vm_id" "$VM_NAME" "$VM_CPU" "${VM_USED_MB} MB" "${VM_MAX_MB:-No limit} MB" "${VM_TOP_PROC:-Agent N/A}"
+    printf "%-6s %-5s %-20s %-12s %-12s %s\n" \
+        "VM" "$vm_id" "$VM_NAME" "${VM_USED_MB} MB" "${VM_MAX_MB:-No limit} MB" "${VM_TOP_PROC:-Agent N/A}"
 done
 
 printf "=================================\n"


### PR DESCRIPTION
Removed the CPU column from the detailed usage table in the `proxmox-ram-monitor.sh` script as it was not being used.

This change includes:
- Removing the CPU data collection for LXC containers and QEMU VMs.
- Updating the table header to remove the "CPU %" column.
- Updating the table rows to reflect the removal of the CPU column.